### PR TITLE
use correct framework

### DIFF
--- a/src/SquareWidget.Astronomy.Core/SquareWidget.Astronomy.Core.csproj
+++ b/src/SquareWidget.Astronomy.Core/SquareWidget.Astronomy.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Title>SquareWidget.Astronomy.Core</Title>
     <Authors>James Still</Authors>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)